### PR TITLE
Add meetings functionality and update schema

### DIFF
--- a/src/app/(dashboard)/meetings/[meetingId]/page.tsx
+++ b/src/app/(dashboard)/meetings/[meetingId]/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>Meeting Id Page</div>;
+};
+
+export default Page;

--- a/src/app/(dashboard)/meetings/page.tsx
+++ b/src/app/(dashboard)/meetings/page.tsx
@@ -1,0 +1,27 @@
+import {
+  MeetingsView,
+  MeetingsViewError,
+  MeetingsViewLoading,
+} from "@/modules/meetings/ui/views/meeting-view";
+import { getQueryClient, trpc } from "@/trpc/server";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+
+const Page = () => {
+  const queryClient = getQueryClient();
+  void queryClient.prefetchQuery(trpc.meetings.getMany.queryOptions({}));
+  return (
+    <div>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <Suspense fallback={<MeetingsViewLoading />}>
+          <ErrorBoundary fallback={<MeetingsViewError />}>
+            <MeetingsView />
+          </ErrorBoundary>
+        </Suspense>
+      </HydrationBoundary>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,6 +4,7 @@ import {
   timestamp,
   boolean,
   integer,
+  pgEnum,
 } from "drizzle-orm/pg-core";
 
 import { nanoid } from "nanoid";
@@ -68,11 +69,44 @@ export const verification = pgTable("verification", {
   ),
 });
 
-export const agents = pgTable("agents",{
-  id:text("id").primaryKey().$defaultFn(()=>nanoid()),
-  name:text("name").notNull(),
-  userId:text("user_id").notNull().references(()=>user.id,{onDelete:"cascade"}),
-  instructions:text("instructions").notNull(),
-  createdAt:timestamp("created_at").notNull().defaultNow(),
-  updatedAt:timestamp("updated_at").notNull().defaultNow(),
-})
+export const agents = pgTable("agents", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => nanoid()),
+  name: text("name").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  instructions: text("instructions").notNull(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+export const meetingStatus = pgEnum("meeting_status", [
+  "upcoming",
+  "active",
+  "completed",
+  "cancelled",
+  "processing",
+]);
+
+export const meetings = pgTable("meetings", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => nanoid()),
+  name: text("name").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  agentId: text("agent_id")
+    .notNull()
+    .references(() => agents.id, { onDelete: "cascade" }),
+  status: meetingStatus("status").notNull().default("upcoming"),
+  startedAt: timestamp("started_at"),
+  endedAt: timestamp("ended_at"),
+  transcriptUrl: text("transcript_url"),
+  recordingUrl: text("recording_url"),
+  summary: text("summary"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});

--- a/src/modules/meetings/server/procedures.ts
+++ b/src/modules/meetings/server/procedures.ts
@@ -1,0 +1,87 @@
+import { db } from "@/db";
+
+import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+
+import { and, count, desc, eq, getTableColumns, ilike, sql } from "drizzle-orm";
+import { z } from "zod";
+import {
+  DEFAULT_PAGE,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  MIN_PAGE_SIZE,
+} from "../../../../contants";
+import { TRPCError } from "@trpc/server";
+import { meetings } from "@/db/schema";
+
+export const meetingsRouter = createTRPCRouter({
+  getMany: protectedProcedure
+    .input(
+      z.object({
+        page: z.number().default(DEFAULT_PAGE),
+        pageSize: z
+          .number()
+          .min(MIN_PAGE_SIZE)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE),
+        search: z.string().nullish(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { page, pageSize, search } = input;
+      const data = await db
+        .select({
+          ...getTableColumns(meetings),
+        })
+        .from(meetings)
+        .where(
+          and(
+            eq(meetings.userId, ctx.auth.user.id),
+            search ? ilike(meetings.name, `%${search}%`) : undefined
+          )
+        )
+        .orderBy(desc(meetings.createdAt), desc(meetings.id))
+        .limit(pageSize)
+        .offset((page - 1) * pageSize);
+
+      const [total] = await db
+        .select({
+          count: count(),
+        })
+        .from(meetings)
+        .where(
+          and(
+            eq(meetings.userId, ctx.auth.user.id),
+            search ? ilike(meetings.name, `%${search}%`) : undefined
+          )
+        );
+
+      const totalPages = Math.ceil(total.count / pageSize);
+
+      return {
+        items: data,
+        totalPages,
+        totalItems: total.count,
+      };
+    }),
+
+  getOne: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input, ctx }) => {
+      const [existingMeeting] = await db
+        .select({
+          ...getTableColumns(meetings),
+        })
+        .from(meetings)
+        .where(
+          and(eq(meetings.id, input.id), eq(meetings.userId, ctx.auth.user.id))
+        );
+      if (!existingMeeting) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Meeting not found",
+        });
+      }
+
+      return existingMeeting;
+    }),
+});

--- a/src/modules/meetings/ui/views/meeting-view.tsx
+++ b/src/modules/meetings/ui/views/meeting-view.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import ErrorState from "@/components/error-state";
+import LoadingState from "@/components/loading-state";
+import { useTRPC } from "@/trpc/client";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+
+export const MeetingsView = () => {
+  const trpc = useTRPC();
+  const { data } = useSuspenseQuery(trpc.meetings.getMany.queryOptions({}));
+  return <div>{JSON.stringify(data)}</div>;
+};
+
+export const MeetingsViewLoading = () => {
+  return (
+    <LoadingState
+      title="Loading Meetings"
+      description="This may take a few seconds"
+    />
+  );
+};
+
+export const MeetingsViewError = () => {
+  return (
+    <ErrorState
+      title="Error Loading Meetings"
+      description="Please try again later"
+    />
+  );
+};

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -1,7 +1,9 @@
 import { agentsRouter } from "@/modules/agents/server/procedures";
+import { meetingsRouter } from "@/modules/meetings/server/procedures";
 import { createTRPCRouter } from "../init";
 export const appRouter = createTRPCRouter({
   agents: agentsRouter,
+  meetings: meetingsRouter,
 });
 // export type definition of API
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
- Introduced `meetingStatus` enum to define various states for meetings.
- Added `meetings` table to the database schema with fields for meeting details, including references to agents and users.
- Updated the TRPC router to include `meetingsRouter`, enabling API access for meeting-related operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a meetings dashboard page with loading and error states.
  - Added the ability to view a list of meetings, including pagination and search functionality.
  - Enabled viewing details for individual meetings.

- **Bug Fixes**
  - Improved error handling and loading feedback when accessing meetings data.

- **Chores**
  - Expanded backend support for meetings, including new database structures and API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->